### PR TITLE
Investigate why execution is slow, bug fix

### DIFF
--- a/src/models/train_node2vec_model.py
+++ b/src/models/train_node2vec_model.py
@@ -27,7 +27,7 @@ def create_graph(edges_df):
 
 
 def train_node2_vec_model(edges_df,
-                          workers=4):
+                          workers=1):
     """
     Train a node2vec model using a DataFrame of edges (source and target node_ids)
     and a mapping of the node_ids (used in the DataFrame) to GOV.UK content_ids

--- a/src/models/train_node2vec_model.py
+++ b/src/models/train_node2vec_model.py
@@ -20,9 +20,12 @@ def create_graph(edges_df):
     cid_dict = dict(zip(list(cids), list(range(0,len(cids)))))
     edges_df['source_content_nid'] = edges_df['source_content_id'].map(cid_dict)
     edges_df['destination_content_nid'] = edges_df['destination_content_id'].map(cid_dict)
-    
-    graph = nx.convert_matrix.from_pandas_edgelist(
-        edges_df, source='source_content_nid', target='destination_content_nid')
+
+    graph = nx.DiGraph()
+    for src, dest in zip(edges_df.source_content_nid, edges_df.destination_content_nid):
+        graph.add_edge(src, dest)
+
+    print(type(graph))
     return graph
 
 

--- a/src/models/train_node2vec_model.py
+++ b/src/models/train_node2vec_model.py
@@ -24,8 +24,12 @@ def create_graph(edges_df):
     graph = nx.DiGraph()
     for src, dest in zip(edges_df.source_content_nid, edges_df.destination_content_nid):
         graph.add_edge(src, dest)
+        
+#     graph = nx.from_pandas_dataframe(edges_df,source='source_content_nid',
+#                                    target='destination_content_nid',
+#                                    create_using=nx.DiGraph())
 
-    print(type(graph))
+#     print(type(graph))
     return graph
 
 

--- a/src/models/train_node2vec_model.py
+++ b/src/models/train_node2vec_model.py
@@ -11,16 +11,24 @@ logging.config.fileConfig('src/logging.conf')
 
 
 def create_graph(edges_df):
+    
     logger = logging.getLogger('train_node2_vec_model.create_graph')
     logger.info('creating graph from edges_df')
+    
+    logger.info("add nid")
+    cids = set(list(edges_df.source_content_id) + list(edges_df.destination_content_id))
+    cid_dict = dict(zip(list(cids), list(range(0,len(cids)))))
+    edges_df['source_content_nid'] = edges_df['source_content_id'].map(cid_dict)
+    edges_df['destination_content_nid'] = edges_df['destination_content_id'].map(cid_dict)
+    
     graph = nx.convert_matrix.from_pandas_edgelist(
-        edges_df, source='source_content_id', target='destination_content_id', edge_attr='weight'
+        edges_df, source='source_content_nid', target='destination_content_nid', edge_attr='weight'
     )
     return graph
 
 
 def train_node2_vec_model(edges_df,
-                          workers=None):
+                          workers=4):
     """
     Train a node2vec model using a DataFrame of edges (source and target node_ids)
     and a mapping of the node_ids (used in the DataFrame) to GOV.UK content_ids

--- a/src/models/train_node2vec_model.py
+++ b/src/models/train_node2vec_model.py
@@ -6,30 +6,16 @@ import networkx as nx
 from node2vec import Node2Vec
 import pandas as pd
 
-
 logging.config.fileConfig('src/logging.conf')
 
 
 def create_graph(edges_df):
-    
     logger = logging.getLogger('train_node2_vec_model.create_graph')
     logger.info('creating graph from edges_df')
-    
-    logger.info("add nid")
-    cids = set(list(edges_df.source_content_id) + list(edges_df.destination_content_id))
-    cid_dict = dict(zip(list(cids), list(range(0,len(cids)))))
-    edges_df['source_content_nid'] = edges_df['source_content_id'].map(cid_dict)
-    edges_df['destination_content_nid'] = edges_df['destination_content_id'].map(cid_dict)
 
-    graph = nx.DiGraph()
-    for src, dest in zip(edges_df.source_content_nid, edges_df.destination_content_nid):
-        graph.add_edge(src, dest)
-        
-#     graph = nx.from_pandas_dataframe(edges_df,source='source_content_nid',
-#                                    target='destination_content_nid',
-#                                    create_using=nx.DiGraph())
-
-#     print(type(graph))
+    graph = nx.from_pandas_edgelist(edges_df, source='source_content_id',
+                                    target='destination_content_id',
+                                    create_using=nx.DiGraph())
     return graph
 
 

--- a/src/models/train_node2vec_model.py
+++ b/src/models/train_node2vec_model.py
@@ -22,8 +22,7 @@ def create_graph(edges_df):
     edges_df['destination_content_nid'] = edges_df['destination_content_id'].map(cid_dict)
     
     graph = nx.convert_matrix.from_pandas_edgelist(
-        edges_df, source='source_content_nid', target='destination_content_nid', edge_attr='weight'
-    )
+        edges_df, source='source_content_nid', target='destination_content_nid')
     return graph
 
 


### PR DESCRIPTION
Node2vec execution ended up being 15+hrs, something not reproducible in local machine/first n2v iteration. Tried out reducing data size and using `node_id` instead of `content_id`, but after all it was the graph initialization. The algo requires digraph, was getting graph (undirected graph) which lead to massive complexity in the walk computation.