### PR TITLE
Automate related links generation and ingestion

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+gem 'gds-api-adapters', '~> 59.3'
+gem 'rake', '~> 12.3', '>= 12.3.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,45 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.6.0)
+      public_suffix (>= 2.0.2, < 4.0)
+    domain_name (0.5.20180417)
+      unf (>= 0.0.5, < 1.0.0)
+    gds-api-adapters (59.3.0)
+      addressable
+      link_header
+      null_logger
+      plek (>= 1.9.0)
+      rack-cache
+      rest-client (~> 2.0)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
+    link_header (0.0.8)
+    mime-types (3.2.2)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2019.0331)
+    netrc (0.11.0)
+    null_logger (0.0.1)
+    plek (2.1.1)
+    public_suffix (3.0.3)
+    rack (2.0.7)
+    rack-cache (1.9.0)
+      rack (>= 0.4)
+    rake (12.3.2)
+    rest-client (2.0.2)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.6)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  gds-api-adapters (~> 59.3)
+  rake (~> 12.3, >= 12.3.2)
+
+BUNDLED WITH
+   2.0.1

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,55 @@
+require 'gds-api-adapters'
+
+namespace :content do
+  desc 'Updates suggested related links for content from a JSON file'
+  task :update_related_links_from_json, [:json_path] do |_, args|
+    puts 'Reading and parsing data...'
+
+    @publishing_api = GdsApi::PublishingApiV2.new(
+     ENV['PUBLISHING_API_URI'],
+     bearer_token: ENV['PUBLISHING_API_BEARER_TOKEN']
+    )
+
+    url = URI.parse(args[:json_path]) rescue false
+    file =
+      if url.is_a?(URI::HTTP) || url.is_a?(URI::HTTPS)
+        url.open(&:read)
+      else
+        File.read(args[:json_path])
+      end
+
+    json = JSON.parse(file)
+
+    @failed_content_ids = []
+
+    start_time = Time.now
+    puts "Start updating content items, at #{start_time}"
+
+    json.each_pair do |source_content_id, related_content_ids|
+      update_content(source_content_id, related_content_ids)
+    end
+
+    end_time = Time.now
+    elapsed_time = end_time - start_time
+
+    puts "Total elapsed time: #{elapsed_time}s"
+    puts "Failed content ids: #{@failed_content_ids}"
+  end
+
+  def update_content(source_content_id, related_content_ids)
+    response = @publishing_api.patch_links(
+      source_content_id,
+      links: {
+        suggested_ordered_related_items: related_content_ids
+      },
+      bulk_publishing: true
+    )
+
+    if response.code == 200
+      puts "Updated related links for content #{source_content_id}"
+    else
+      @failed_content_ids << source_content_id
+      STDERR.puts "Failed to update content id #{source_content_id} - response status #{response.code}"
+    end
+  end
+end

--- a/concourse.yml
+++ b/concourse.yml
@@ -2,9 +2,13 @@ groups:
   - name: link-generation
     jobs: 
       - run-generation-integration
+      - run-generation-staging
+      - run-generation-production
   - name: link-ingestion
     jobs:
       - run-ingestion-integration
+      - run-ingestion-staging
+      - run-ingestion-production
 
 jobs:
   - name: run-generation-integration
@@ -17,7 +21,7 @@ jobs:
           params:
             DESIRED_CAPACITY: 1
             ASG_NAME: related-links-generation
-            ROLE_ARN: ((concourse_role_arn))
+            ROLE_ARN: ((concourse_role_arn_integration))
           platform: linux
           image_resource:
             type: docker-image
@@ -40,14 +44,14 @@ jobs:
       - task: wait-for-instance
         config:
           params:
-            ROLE_ARN: ((concourse_role_arn))
+            ROLE_ARN: ((concourse_role_arn_integration))
           platform: linux
           image_resource:
             type: docker-image
             source:
               repository: govsvc/task-toolbox
               tag: 1.1.0
-          run:
+          run: &wait-for-instance
             path: bash
             args:
               - -c
@@ -74,7 +78,7 @@ jobs:
           params:
             CONCOURSE_PRIVATE_KEY: ((concourse_private_key))
             BIG_QUERY_CREDENTIALS: ((big_query_credentials))
-            ROLE_ARN: ((concourse_role_arn))
+            ROLE_ARN: ((concourse_role_arn_integration))
             CONTENT_STORE_BUCKET: ((content_store_bucket_integration))
             RELATED_LINKS_BUCKET: ((related_links_bucket_integration))
           platform: linux
@@ -83,7 +87,7 @@ jobs:
             source:
               repository: govsvc/task-toolbox
               tag: 1.1.0
-          run:
+          run: &provision-generation-instance
             path: bash
             args:
               - -c
@@ -137,14 +141,14 @@ jobs:
         config:
           params:
             CONCOURSE_PRIVATE_KEY: ((concourse_private_key))
-            ROLE_ARN: ((concourse_role_arn))
+            ROLE_ARN: ((concourse_role_arn_integration))
           platform: linux
           image_resource:
             type: docker-image
             source:
               repository: govsvc/task-toolbox
               tag: 1.1.0
-          run:
+          run: &watch-instance
             path: bash
             args:
               - -c
@@ -178,7 +182,147 @@ jobs:
           params:
             DESIRED_CAPACITY: 0
             ASG_NAME: related-links-generation
-            ROLE_ARN: ((concourse_role_arn))
+            ROLE_ARN: ((concourse_role_arn_integration))
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: govsvc/task-toolbox
+              tag: 1.1.0
+          run: *update-asg
+
+  - name: run-generation-staging
+    serial_groups: 
+      - link-generation
+    on_failure: *destroy-generation-instance
+    plan:
+      - task: create-generation-instance
+        config:
+          params:
+            DESIRED_CAPACITY: 1
+            ASG_NAME: related-links-generation
+            ROLE_ARN: ((concourse_role_arn_staging))
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: govsvc/task-toolbox
+              tag: 1.1.0
+          run: *update-asg
+      - task: wait-for-instance
+        config:
+          params:
+            ROLE_ARN: ((concourse_role_arn_staging))
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: govsvc/task-toolbox
+              tag: 1.1.0
+          run: *wait-for-instance
+      - task: provision-instance
+        config:
+          params:
+            CONCOURSE_PRIVATE_KEY: ((concourse_private_key))
+            BIG_QUERY_CREDENTIALS: ((big_query_credentials))
+            ROLE_ARN: ((concourse_role_arn_staging))
+            CONTENT_STORE_BUCKET: ((content_store_bucket_staging))
+            RELATED_LINKS_BUCKET: ((related_links_bucket_staging))
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: govsvc/task-toolbox
+              tag: 1.1.0
+          run: *provision-generation-instance
+      - task: watch-instance
+        config:
+          params:
+            CONCOURSE_PRIVATE_KEY: ((concourse_private_key))
+            ROLE_ARN: ((concourse_role_arn_staging))
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: govsvc/task-toolbox
+              tag: 1.1.0
+          run: *watch-instance
+      - task: destroy-generation-instance
+        config:
+          params:
+            DESIRED_CAPACITY: 0
+            ASG_NAME: related-links-generation
+            ROLE_ARN: ((concourse_role_arn_staging))
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: govsvc/task-toolbox
+              tag: 1.1.0
+          run: *update-asg
+
+  - name: run-generation-production
+    serial_groups: 
+      - link-generation
+    on_failure: *destroy-generation-instance
+    plan:
+      - task: create-generation-instance
+        config:
+          params:
+            DESIRED_CAPACITY: 1
+            ASG_NAME: related-links-generation
+            ROLE_ARN: ((concourse_role_arn_production))
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: govsvc/task-toolbox
+              tag: 1.1.0
+          run: *update-asg
+      - task: wait-for-instance
+        config:
+          params:
+            ROLE_ARN: ((concourse_role_arn_production))
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: govsvc/task-toolbox
+              tag: 1.1.0
+          run: *wait-for-instance
+      - task: provision-instance
+        config:
+          params:
+            CONCOURSE_PRIVATE_KEY: ((concourse_private_key))
+            BIG_QUERY_CREDENTIALS: ((big_query_credentials))
+            ROLE_ARN: ((concourse_role_arn_production))
+            CONTENT_STORE_BUCKET: ((content_store_bucket_production))
+            RELATED_LINKS_BUCKET: ((related_links_bucket_production))
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: govsvc/task-toolbox
+              tag: 1.1.0
+          run: *provision-generation-instance
+      - task: watch-instance
+        config:
+          params:
+            CONCOURSE_PRIVATE_KEY: ((concourse_private_key))
+            ROLE_ARN: ((concourse_role_arn_production))
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: govsvc/task-toolbox
+              tag: 1.1.0
+          run: *watch-instance
+      - task: destroy-generation-instance
+        config:
+          params:
+            DESIRED_CAPACITY: 0
+            ASG_NAME: related-links-generation
+            ROLE_ARN: ((concourse_role_arn_production))
           platform: linux
           image_resource:
             type: docker-image
@@ -197,7 +341,7 @@ jobs:
           params:
             DESIRED_CAPACITY: 1
             ASG_NAME: related-links-ingestion
-            ROLE_ARN: ((concourse_role_arn))
+            ROLE_ARN: ((concourse_role_arn_integration))
           platform: linux
           image_resource:
             type: docker-image
@@ -208,14 +352,14 @@ jobs:
       - task: wait-for-instance
         config:
           params:
-            ROLE_ARN: ((concourse_role_arn))
+            ROLE_ARN: ((concourse_role_arn_integration))
           platform: linux
           image_resource:
             type: docker-image
             source:
               repository: govsvc/task-toolbox
               tag: 1.1.0
-          run:
+          run: &wait-for-ingestion-instance
             path: bash
             args:
               - -c
@@ -241,7 +385,7 @@ jobs:
         config:
           params:
             CONCOURSE_PRIVATE_KEY: ((concourse_private_key))
-            ROLE_ARN: ((concourse_role_arn))
+            ROLE_ARN: ((concourse_role_arn_integration))
             PUBLISHING_API_URI: ((publishing_api_uri_integration))
             PUBLISHING_API_BEARER_TOKEN: ((publishing_api_bearer_token_integration))
             RELATED_LINKS_BUCKET: ((related_links_bucket_integration))
@@ -251,7 +395,7 @@ jobs:
             source:
               repository: govsvc/task-toolbox
               tag: 1.1.0
-          run:
+          run: &provision-ingestion-instance
             path: bash
             args:
               - -c
@@ -305,14 +449,14 @@ jobs:
         config:
           params:
             CONCOURSE_PRIVATE_KEY: ((concourse_private_key))
-            ROLE_ARN: ((concourse_role_arn))
+            ROLE_ARN: ((concourse_role_arn_integration))
           platform: linux
           image_resource:
             type: docker-image
             source:
               repository: govsvc/task-toolbox
               tag: 1.1.0
-          run:
+          run: &watch-ingestion-instance
             path: bash
             args:
               - -c
@@ -346,7 +490,147 @@ jobs:
           params:
             DESIRED_CAPACITY: 0
             ASG_NAME: related-links-ingestion
-            ROLE_ARN: ((concourse_role_arn))
+            ROLE_ARN: ((concourse_role_arn_integration))
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: govsvc/task-toolbox
+              tag: 1.1.0
+          run: *update-asg
+
+  - name: run-ingestion-staging
+    serial_groups: 
+      - link-ingestion
+    on_failure: *destroy-ingestion-instance
+    plan:
+      - task: create-ingestion-instance
+        config:
+          params:
+            DESIRED_CAPACITY: 1
+            ASG_NAME: related-links-ingestion
+            ROLE_ARN: ((concourse_role_arn_staging))
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: govsvc/task-toolbox
+              tag: 1.1.0
+          run: *update-asg
+      - task: wait-for-instance
+        config:
+          params:
+            ROLE_ARN: ((concourse_role_arn_staging))
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: govsvc/task-toolbox
+              tag: 1.1.0
+          run: *wait-for-ingestion-instance
+      - task: provision-ingestion-instance
+        config:
+          params:
+            CONCOURSE_PRIVATE_KEY: ((concourse_private_key))
+            ROLE_ARN: ((concourse_role_arn_staging))
+            PUBLISHING_API_URI: ((publishing_api_uri_staging))
+            PUBLISHING_API_BEARER_TOKEN: ((publishing_api_bearer_token_staging))
+            RELATED_LINKS_BUCKET: ((related_links_bucket_staging))
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: govsvc/task-toolbox
+              tag: 1.1.0
+          run: *provision-ingestion-instance
+      - task: watch-ingestion-instance
+        config:
+          params:
+            CONCOURSE_PRIVATE_KEY: ((concourse_private_key))
+            ROLE_ARN: ((concourse_role_arn_staging))
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: govsvc/task-toolbox
+              tag: 1.1.0
+          run: *watch-ingestion-instance
+      - task: destroy-ingestion-instance
+        config:
+          params:
+            DESIRED_CAPACITY: 0
+            ASG_NAME: related-links-ingestion
+            ROLE_ARN: ((concourse_role_arn_staging))
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: govsvc/task-toolbox
+              tag: 1.1.0
+          run: *update-asg
+
+  - name: run-ingestion-production
+    serial_groups: 
+      - link-ingestion
+    on_failure: *destroy-ingestion-instance
+    plan:
+      - task: create-ingestion-instance
+        config:
+          params:
+            DESIRED_CAPACITY: 1
+            ASG_NAME: related-links-ingestion
+            ROLE_ARN: ((concourse_role_arn_production))
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: govsvc/task-toolbox
+              tag: 1.1.0
+          run: *update-asg
+      - task: wait-for-instance
+        config:
+          params:
+            ROLE_ARN: ((concourse_role_arn_production))
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: govsvc/task-toolbox
+              tag: 1.1.0
+          run: *wait-for-ingestion-instance
+      - task: provision-ingestion-instance
+        config:
+          params:
+            CONCOURSE_PRIVATE_KEY: ((concourse_private_key))
+            ROLE_ARN: ((concourse_role_arn_production))
+            PUBLISHING_API_URI: ((publishing_api_uri_production))
+            PUBLISHING_API_BEARER_TOKEN: ((publishing_api_bearer_token_production))
+            RELATED_LINKS_BUCKET: ((related_links_bucket_production))
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: govsvc/task-toolbox
+              tag: 1.1.0
+          run: *provision-ingestion-instance
+      - task: watch-ingestion-instance
+        config:
+          params:
+            CONCOURSE_PRIVATE_KEY: ((concourse_private_key))
+            ROLE_ARN: ((concourse_role_arn_production))
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: govsvc/task-toolbox
+              tag: 1.1.0
+          run: *watch-ingestion-instance
+      - task: destroy-ingestion-instance
+        config:
+          params:
+            DESIRED_CAPACITY: 0
+            ASG_NAME: related-links-ingestion
+            ROLE_ARN: ((concourse_role_arn_production))
           platform: linux
           image_resource:
             type: docker-image

--- a/concourse.yml
+++ b/concourse.yml
@@ -1,0 +1,357 @@
+groups:
+  - name: link-generation
+    jobs: 
+      - run-generation-integration
+  - name: link-ingestion
+    jobs:
+      - run-ingestion-integration
+
+jobs:
+  - name: run-generation-integration
+    serial_groups: 
+      - link-generation
+    on_failure: *destroy-generation-instance
+    plan:
+      - task: create-generation-instance
+        config:
+          params:
+            DESIRED_CAPACITY: 1
+            ASG_NAME: related-links-generation
+            ROLE_ARN: ((concourse_role_arn))
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: govsvc/task-toolbox
+              tag: 1.1.0
+          run: &update-asg
+            path: bash
+            args:
+              - -c
+              - |
+                set -e pipefail
+                eval $(aws-assume-role $ROLE_ARN)
+                echo Assumed role successfully
+                aws autoscaling set-desired-capacity \
+                  --auto-scaling-group-name $ASG_NAME \
+                  --desired-capacity $DESIRED_CAPACITY \
+                  --region eu-west-1
+                echo Set desired-capacity
+      - task: wait-for-instance
+        config:
+          params:
+            ROLE_ARN: ((concourse_role_arn))
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: govsvc/task-toolbox
+              tag: 1.1.0
+          run:
+            path: bash
+            args:
+              - -c
+              - |
+                set -ueo pipefail
+
+                eval $(aws-assume-role $ROLE_ARN)
+                echo Assumed role successfully
+
+                echo "Sleeping for 30s to give AWS chance to start EC2..."
+                sleep 30
+
+                instance_id=$(aws ec2 describe-instances --region eu-west-1 --query "Reservations[*].Instances[*].InstanceId" --filters Name=instance-state-name,Values=running,pending  Name=tag:Name,Values=related-links-generation --output=text)
+                
+                echo "Waiting on instance ${instance_id}..."
+
+                aws ec2 wait instance-status-ok \
+                  --region eu-west-1 \
+                  --instance-ids ${instance_id}
+                
+                echo "Instance available and ready"
+      - task: provision-instance
+        config:
+          params:
+            CONCOURSE_PRIVATE_KEY: ((concourse_private_key))
+            BIG_QUERY_CREDENTIALS: ((big_query_credentials))
+            ROLE_ARN: ((concourse_role_arn))
+            CONTENT_STORE_BUCKET: ((content_store_bucket_integration))
+            RELATED_LINKS_BUCKET: ((related_links_bucket_integration))
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: govsvc/task-toolbox
+              tag: 1.1.0
+          run:
+            path: bash
+            args:
+              - -c
+              - |
+                set -eo pipefail
+
+                eval $(aws-assume-role $ROLE_ARN)
+                echo Assumed role successfully
+
+                echo "$CONCOURSE_PRIVATE_KEY" > /tmp/concourse_ssh_key
+                chmod 400 /tmp/concourse_ssh_key
+
+                instance_ip=$(aws ec2 describe-instances --region eu-west-1 --query "Reservations[*].Instances[*].PublicIpAddress" --filter Name=tag:Name,Values=related-links-generation --output=text)
+                
+                echo "Connecting to instance..."
+                ssh -i /tmp/concourse_ssh_key -o StrictHostKeyChecking=no ubuntu@${instance_ip} << EOF
+                  echo "Connected!"
+
+                  # Setup data directory
+                  sudo mkdir /var/data
+                  sudo chown ubuntu /var/data
+
+                  # Setup Github directory
+                  mkdir /var/data/github
+                  cd /var/data/github
+
+                  # Clone related links repository
+                  git clone https://github.com/alphagov/govuk-related-links-recommender.git
+                  cd govuk-related-links-recommender
+
+                  # Set execute permission on scripts
+                  chmod +x ./provision_generation_machine
+                  chmod +x ./run_link_generation
+
+                  # Make bucket names accessible to scripts
+                  export CONTENT_STORE_BUCKET="$CONTENT_STORE_BUCKET"
+                  export RELATED_LINKS_BUCKET="$RELATED_LINKS_BUCKET"
+                  export BIG_QUERY_CREDENTIALS='$BIG_QUERY_CREDENTIALS'
+
+                  # Create log file
+                  touch /var/tmp/related_links_process.log
+
+                  echo "Provisioning machine..."
+                  ./provision_generation_machine
+
+                  echo "Running link generation in background..."
+                  echo "Writing log to /var/tmp/related_links_process.log"
+                  ./run_link_generation > /var/tmp/related_links_process.log 2>&1 &
+                EOF
+      - task: watch-instance
+        config:
+          params:
+            CONCOURSE_PRIVATE_KEY: ((concourse_private_key))
+            ROLE_ARN: ((concourse_role_arn))
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: govsvc/task-toolbox
+              tag: 1.1.0
+          run:
+            path: bash
+            args:
+              - -c
+              - |
+                set -eo pipefail
+
+                eval $(aws-assume-role $ROLE_ARN)
+                echo Assumed role successfully
+
+                echo "$CONCOURSE_PRIVATE_KEY" > /tmp/concourse_ssh_key
+                chmod 400 /tmp/concourse_ssh_key
+
+                # Update SSH config to keep connection alive
+                echo "ServerAliveInterval 300" >> /etc/ssh/ssh_config
+
+                instance_id=$(aws ec2 describe-instances --region eu-west-1 --query "Reservations[*].Instances[*].PublicIpAddress" --filter Name=tag:Name,Values=related-links-generation --output=text)
+                
+                echo "Connecting to instance..."
+                ssh -i /tmp/concourse_ssh_key -o StrictHostKeyChecking=no ubuntu@${instance_id} <<EOF
+                  echo "Connected!"
+
+                  cd /var/data/github/govuk-related-links-recommender
+
+                  chmod +x ./monitor_related_links_process
+
+                  ./monitor_related_links_process
+                EOF
+      - &destroy-generation-instance
+        task: destroy-generation-instance
+        config:
+          params:
+            DESIRED_CAPACITY: 0
+            ASG_NAME: related-links-generation
+            ROLE_ARN: ((concourse_role_arn))
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: govsvc/task-toolbox
+              tag: 1.1.0
+          run: *update-asg
+
+  - name: run-ingestion-integration
+    serial_groups: 
+      - link-ingestion
+    on_failure: *destroy-ingestion-instance
+    plan:
+      - task: create-ingestion-instance
+        config:
+          params:
+            DESIRED_CAPACITY: 1
+            ASG_NAME: related-links-ingestion
+            ROLE_ARN: ((concourse_role_arn))
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: govsvc/task-toolbox
+              tag: 1.1.0
+          run: *update-asg
+      - task: wait-for-instance
+        config:
+          params:
+            ROLE_ARN: ((concourse_role_arn))
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: govsvc/task-toolbox
+              tag: 1.1.0
+          run:
+            path: bash
+            args:
+              - -c
+              - |
+                set -ueo pipefail
+
+                eval $(aws-assume-role $ROLE_ARN)
+                echo Assumed role successfully
+
+                echo "Sleeping for 30s to give AWS chance to start EC2..."
+                sleep 30
+
+                instance_id=$(aws ec2 describe-instances --region eu-west-1 --query "Reservations[*].Instances[*].InstanceId" --filters Name=instance-state-name,Values=running,pending  Name=tag:Name,Values=related-links-ingestion --output=text)
+                
+                echo "Waiting on instance ${instance_id}..."
+
+                aws ec2 wait instance-status-ok \
+                  --region eu-west-1 \
+                  --instance-ids ${instance_id}
+                
+                echo "Instance available and ready"
+      - task: provision-ingestion-instance
+        config:
+          params:
+            CONCOURSE_PRIVATE_KEY: ((concourse_private_key))
+            ROLE_ARN: ((concourse_role_arn))
+            PUBLISHING_API_URI: ((publishing_api_uri_integration))
+            PUBLISHING_API_BEARER_TOKEN: ((publishing_api_bearer_token_integration))
+            RELATED_LINKS_BUCKET: ((related_links_bucket_integration))
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: govsvc/task-toolbox
+              tag: 1.1.0
+          run:
+            path: bash
+            args:
+              - -c
+              - |
+                set -ueo pipefail
+
+                eval $(aws-assume-role $ROLE_ARN)
+                echo Assumed role successfully
+
+                echo "$CONCOURSE_PRIVATE_KEY" > /tmp/concourse_ssh_key
+                chmod 400 /tmp/concourse_ssh_key
+
+                instance_ip=$(aws ec2 describe-instances --region eu-west-1 --query "Reservations[*].Instances[*].PublicIpAddress" --filter Name=tag:Name,Values=related-links-ingestion --output=text)
+                
+                echo "Connecting to instance ${instance_ip}..."
+                ssh -i /tmp/concourse_ssh_key -o StrictHostKeyChecking=no ubuntu@${instance_ip} << EOF
+                  echo "Connected!"
+
+                  # Setup data directory
+                  sudo mkdir /var/data
+                  sudo chown ubuntu /var/data
+
+                  # Setup Github directory
+                  mkdir /var/data/github
+                  cd /var/data/github
+
+                  # Clone related links repository
+                  git clone https://github.com/alphagov/govuk-related-links-recommender.git
+                  cd govuk-related-links-recommender
+
+                  # Set execute permission on scripts
+                  chmod +x ./provision_ingestion_machine
+                  chmod +x ./run_link_ingestion
+
+                  # Make environment variables accessible to scripts
+                  export RELATED_LINKS_BUCKET="$RELATED_LINKS_BUCKET"
+                  export PUBLISHING_API_URI="$PUBLISHING_API_URI"
+                  export PUBLISHING_API_BEARER_TOKEN="$PUBLISHING_API_BEARER_TOKEN"
+
+                  # Create log file
+                  touch /var/tmp/related_links_process.log
+
+                  echo "Provisioning machine..."
+                  ./provision_ingestion_machine
+
+                  echo "Running link ingestion in background..."
+                  echo "Writing log to /var/tmp/related_links_process.log"
+                  ./run_link_ingestion > /var/tmp/related_links_process.log 2>&1 &
+                EOF
+      - task: watch-ingestion-instance
+        config:
+          params:
+            CONCOURSE_PRIVATE_KEY: ((concourse_private_key))
+            ROLE_ARN: ((concourse_role_arn))
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: govsvc/task-toolbox
+              tag: 1.1.0
+          run:
+            path: bash
+            args:
+              - -c
+              - |
+                set -ueo pipefail
+
+                eval $(aws-assume-role $ROLE_ARN)
+                echo Assumed role successfully
+
+                echo "$CONCOURSE_PRIVATE_KEY" > /tmp/concourse_ssh_key
+                chmod 400 /tmp/concourse_ssh_key
+
+                # Update SSH config to keep connection alive
+                echo "ServerAliveInterval 300" >> /etc/ssh/ssh_config
+
+                instance_ip=$(aws ec2 describe-instances --region eu-west-1 --query "Reservations[*].Instances[*].PublicIpAddress" --filter Name=tag:Name,Values=related-links-ingestion --output=text)
+                
+                echo "Connecting to instance..."
+                ssh -i /tmp/concourse_ssh_key -o StrictHostKeyChecking=no ubuntu@${instance_ip} <<EOF
+                  echo "Connected!"
+
+                  cd /var/data/github/govuk-related-links-recommender
+
+                  chmod +x ./monitor_related_links_process
+
+                  ./monitor_related_links_process
+                EOF
+      - &destroy-ingestion-instance
+        task: destroy-ingestion-instance
+        config:
+          params:
+            DESIRED_CAPACITY: 0
+            ASG_NAME: related-links-ingestion
+            ROLE_ARN: ((concourse_role_arn))
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: govsvc/task-toolbox
+              tag: 1.1.0
+          run: *update-asg
+

--- a/monitor_related_links_process
+++ b/monitor_related_links_process
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -eo pipefail
+
+LINK_PROCESS_PID="$(ps aux | grep run_link_ | grep -v grep | awk '{print $2}')"
+echo "PID of the link generation / ingestion process is $LINK_PROCESS_PID"
+
+tail -f --pid=$LINK_PROCESS_PID /var/tmp/related_links_process.log

--- a/provision_generation_machine
+++ b/provision_generation_machine
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -ueo pipefail
+
+# Install updates and required packages
+sudo apt-get update -y
+sudo apt-get install -y awscli
+sudo apt-get install -y jq
+
+# Install Mongo
+sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 9DA31620334BD75D9DCB49F368818C72E52529D4
+
+echo "deb [ arch=amd64 ] https://repo.mongodb.org/apt/ubuntu bionic/mongodb-org/4.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-4.0.list
+sudo apt-get update
+sudo apt-get install -y mongodb-org
+sudo service mongod start
+
+# Install Python 3 and Pip
+sudo apt-get install python3.6
+sudo apt install -y python3-pip
+
+# Allow others access to instance
+echo "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDDAZQOvxUVgi4IWwfEqYQkqU2b9RGpEHfCB48CmwdRP3WY8Cfre/GH6gw+wLvNvIDuUGLr2hwBhvqoWxsC0EeDMTvgYQE6//zb3ZCw6owMdSmkzHfSkcVvM4JGvuNWIOFYIcMtF9DkGddM5jQD9Inzb+TtPaQjrp8u4hZqr0agjSxwQGxa6hl0TfI4zXNg5Q4TXdEDuhauGomUN+6hK4wRfJW2cdXZBadAbDHAsMNrbEPBcaD8z+SJ23qT5mE5N4aGxbscKqNfq0hTdHUUzDY3Y5bw/Odt5Z9JZNE3/amBwMDRBF0oIEs1+jztRgjPZq2o2jl9EFpu7XToZU+1LGs8m4JDAAyf4BgwX5kdIrkO/MOEsGTY/dqnpwzNNBzfE4pxW4P4frqS1xPP4X5DbDiVD2lu4adffaMOmPU8cy9YyMMxEK62yCCMry1TU7SYr/o1gRcIPRk2m3ZifODZEp9AStRwAeWQfn2fgv2naL8wVd24pdl2/LKuxe1txQTwc6KFKOAylUCEHUJ2NDG5x2XSAGmE/oecUgexxIgHR2nhG3YRt30T8qimEPrY7Tarb3Dei/kHTBJkg3wOLRMGG81L0cE9wvTt6em5jtKXU/tvB16lvi5cgNO++Lmy7GlcZYfbdYZi/CELCBEZye5m9vZT7Jzm26JK75HA3sgtqajMKw== suganya.sivaskantharajah@digital.cabinet-office.gov.uk" >> /home/ubuntu/.ssh/authorized_keys
+echo "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCo6AI0U+VFs2dkrwNDMKcU7j5lhSPFDuboQrsGyC1tv8aUBlCSfVDaPRPT20lYANN7tFgQD9mKXaMlUd9bCJJFs7L3CbE+/kSQCE85rfPFDaTMb3/WzYzwMjDD05pRtvdBwmkS6o8IFA4Yyd29qahYhnrO3jexBIZnNdM4nWZCac+nX/8bWckPOGWIR7fTNWoS8C8tioiUDqa/ZflzGqA0NKv7M0I1kwKqHt25FHaqZxnGmnKEC9QIUGbS4cC1cJQ2AO3NqJGPWhb39QrZwvv+Juh9rU3vuohDfx7Xm1Lh8NMVf3+c1vNTcK+DvaGGLZJ20JUBXlRRFFviLo9eaaf5fHIn5bM9aKFwxoPZtlj73FQpv04bUJf/LlbnGgLeW+B6Pl2w2qFp3u5p5NtvPEnLLPm4ljiPsJwl6vdmZy/xLc8/Ze0xyOeMaENm9MFK8BykgBqXqmEsSntvryP2fp1LgwDOt9ufLpF+yLq6hXl/JKYDJZiCTUjpwSbO/GRbsf2PCjzcwLxKIru3QtR9IZmiopeYRbDvH6Zofs/4M4mQVlBv15CKthVSTwwvcb9vOQyRa2uRW6FkY//g04+2yXpU742Cuh0CgNUd1fJ/vO3kCO0Fup/m3M0B7Vsr4NE5/0XdZSXOd5sF9oB4uVh9vE7apD0+hGbeQHzXz5cRNn52KQ== karl.alec.baker@gmail.com" >> /home/ubuntu/.ssh/authorized_keys

--- a/provision_ingestion_machine
+++ b/provision_ingestion_machine
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -eo pipefail
+
+# Install updates and required packages
+sudo apt-get update -y
+sudo apt-get install -y awscli
+sudo apt-get install -y jq
+sudo apt-get install -y gnupg2
+
+# Install RVM dependencies
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -yq curl g++ gcc autoconf automake bison libc6-dev libffi-dev libgdbm-dev libncurses5-dev libsqlite3-dev libtool libyaml-dev make pkg-config sqlite3 zlib1g-dev libgmp-dev libreadline-dev libssl-dev
+
+# Install RVM and Ruby 2.6.3
+curl -sSL https://rvm.io/mpapis.asc | gpg2 --import -
+curl -sSL https://rvm.io/pkuczynski.asc | gpg2 --import -
+curl -sSL https://get.rvm.io | bash -s stable
+
+source /home/ubuntu/.rvm/scripts/rvm
+rvm install 2.6.3

--- a/run_link_generation
+++ b/run_link_generation
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+set -ueo pipefail
+
+echo "Starting run_link_generation script..."
+sleep 60
+
+export DATA_DIR=$PWD/data
+export MODEL_DIR=$PWD/models
+export GOOGLE_APPLICATION_CREDENTIALS=/var/tmp/bigquery.json
+
+# Store Big Query credentials
+echo $BIG_QUERY_CREDENTIALS > /var/tmp/bigquery.json
+chmod 400 /var/tmp/bigquery.json
+
+# Find and download the latest content store backup from S3
+echo "Finding latest content backup..."
+LATEST_CONTENT_BACKUP_PATH=$(aws s3api list-objects-v2 --bucket $CONTENT_STORE_BUCKET --query "Contents[?contains(Key, '-content_store_production.gz')]" | jq  -c "max_by(.LastModified)|.Key" | xargs)
+
+echo "Downloading latest content store backup..."
+aws s3 cp s3://$CONTENT_STORE_BUCKET/$LATEST_CONTENT_BACKUP_PATH /var/data/latest_content_store_backup.gz
+
+# Extract content store backup
+cd /var/data
+tar -xvf latest_content_store_backup.gz
+ls -lat content_store_production
+
+# Restore content store data to MongoDb
+mongorestore -d content_store -c content_items /var/data/content_store_production/content_items.bson
+
+# Install requirements
+cd /var/data/github/govuk-related-links-recommender
+pip3 install -r requirements.txt
+
+# Start related links generation process
+python3.6 src/run_all.py
+
+cd /var/data/github/govuk-related-links-recommender/data/predictions
+
+SUGGESTED_LINKS_JSON="$(ls -t | grep suggested_related_links.json | head -1)"
+SUGGESTED_LINKS_CSV="$(ls -t | grep suggested_related_links.csv | head -1)"
+
+# Copy outputs to S3
+aws s3 cp $DATA_DIR/predictions/$SUGGESTED_LINKS_JSON s3://$RELATED_LINKS_BUCKET/related_links.json
+aws s3 cp $DATA_DIR/predictions/$SUGGESTED_LINKS_CSV s3://$RELATED_LINKS_BUCKET/related_links.csv
+
+aws s3 cp $DATA_DIR/tmp/structural_edges.csv s3://$RELATED_LINKS_BUCKET/structural_edges.csv
+aws s3 cp $DATA_DIR/tmp/functional_edges.csv s3://$RELATED_LINKS_BUCKET/functional_edges.csv
+aws s3 cp $DATA_DIR/tmp/network.csv s3://$RELATED_LINKS_BUCKET/network.csv
+aws s3 cp $MODEL_DIR/n2v.model s3://$RELATED_LINKS_BUCKET/n2v.model
+
+aws s3 cp /tmp/govuk-related-links-recommender.log s3://$RELATED_LINKS_BUCKET/govuk-related-links-recommender.log
+aws s3 cp /var/tmp/related_links_process.log s3://$RELATED_LINKS_BUCKET/related_links_generation.log

--- a/run_link_ingestion
+++ b/run_link_ingestion
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -eo pipefail
+
+echo "Starting run_link_ingestion script..."
+sleep 60
+
+# Find and download the latest related links JSON from S3
+LATEST_RELATED_LINKS_PATH=$(aws s3api list-objects-v2 --bucket $RELATED_LINKS_BUCKET --query "Contents[?contains(Key, '_related_links.json')]" | jq  -c "max_by(.LastModified)|.Key" | xargs)
+aws s3 cp s3://$RELATED_LINKS_BUCKET/${LATEST_RELATED_LINKS_PATH} /var/data/latest_related_links.json
+
+# Install Bundler and gems
+source /home/ubuntu/.rvm/scripts/rvm
+
+# Switch to required Ruby version
+rvm use ruby-2.6.3
+
+# Install dependencies
+gem install bundler
+bundle
+
+# Run publishing
+bundle exec rake content:update_related_links_from_json['/var/data/latest_related_links.json'] 
+
+# Copy log to S3
+aws s3 cp /var/tmp/related_links_process.log s3://$RELATED_LINKS_BUCKET/related_links_ingestion.log


### PR DESCRIPTION
This commit adds our configuration for the Concourse pipeline, which is split into two groups - `link-generation` and `link-ingestion`.

`link-generation` has been fully defined and contains all of the tasks required for a complete run, which include spinning up the EC2, provisioning the EC2, running the link generation process and finally spinning down the EC2. The scripts which provision the machine and which run the link generation process have been split out into `./provision_machine` and `./run_link_generation` scripts respectively.