### PR TITLE
don't have the logger in self

### DIFF
--- a/src/models/train_node2vec_model.py
+++ b/src/models/train_node2vec_model.py
@@ -15,14 +15,15 @@ class EpochLogger(CallbackAny2Vec):
     """Callback to log information about training'"""
 
     def __init__(self):
-        self.logger = logging.getLogger('train_node2_vec_model.epoch_logger')
         self.epoch = 0
 
     def on_epoch_begin(self, model):
-        self.logger.info(f'Model training epoch #{self.epoch} begun')
+        logger = logging.getLogger('train_node2_vec_model.epoch_logger')
+        logger.info(f'Model training epoch #{self.epoch} begun')
 
     def on_epoch_end(self, model):
-        self.logger.info(f'Model training epoch #{self.epoch} ended')
+        logger = logging.getLogger('train_node2_vec_model.epoch_logger')
+        logger.info(f'Model training epoch #{self.epoch} ended')
         self.epoch += 1
 
 


### PR DESCRIPTION
if the logger is in self then saving the model tries to serialize the logger? Basically it doesn't like it, if we do it this way then we can save the model.