### PR TITLE
Revert "don't have the logger in self"

### DIFF
--- a/src/models/train_node2vec_model.py
+++ b/src/models/train_node2vec_model.py
@@ -15,15 +15,14 @@ class EpochLogger(CallbackAny2Vec):
     """Callback to log information about training'"""
 
     def __init__(self):
+        self.logger = logging.getLogger('train_node2_vec_model.epoch_logger')
         self.epoch = 0
 
     def on_epoch_begin(self, model):
-        logger = logging.getLogger('train_node2_vec_model.epoch_logger')
-        logger.info(f'Model training epoch #{self.epoch} begun')
+        self.logger.info(f'Model training epoch #{self.epoch} begun')
 
     def on_epoch_end(self, model):
-        logger = logging.getLogger('train_node2_vec_model.epoch_logger')
-        logger.info(f'Model training epoch #{self.epoch} ended')
+        self.logger.info(f'Model training epoch #{self.epoch} ended')
         self.epoch += 1
 
 


### PR DESCRIPTION
Reverts alphagov/govuk-related-links-recommender#24

The problem was not the logger with EpochLogger but the fact that the EpochLogger was not within scope of Pickle. This will be fixed in the next PR.