### PR TITLE
Add support for TSV export

### DIFF
--- a/src/utils/related_links_csv_exporter.py
+++ b/src/utils/related_links_csv_exporter.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import numpy as np
+import os
 
 
 class RelatedLinksCsvExporter:
@@ -19,6 +20,9 @@ class RelatedLinksCsvExporter:
         :return:
         """
 
+        file_extension = os.path.splitext(file_path)[1]
+        sep = '\t' if file_extension == '.tsv' else ','
+
         row_list = [{'source_content_id': source_cid,
                      'source_base_path': self.content_id_to_base_path_mapper[source_cid],
                      'target_content_id': target_cid,
@@ -28,4 +32,4 @@ class RelatedLinksCsvExporter:
                      'target_page_views': self.content_ids_to_page_views_mapper.get(target_cid, np.nan)} for source_cid, results in self.related_links.items() for target_cid, prob in results]
         df_with_paths = pd.DataFrame(row_list,
                                   columns=['source_base_path', 'target_base_path', 'probability', 'source_content_id', 'target_content_id', 'source_page_views', 'target_page_views'])
-        df_with_paths.to_csv(file_path, index=False)
+        df_with_paths.to_csv(file_path, index=False, sep=sep)

--- a/src/utils/related_links_json_exporter.py
+++ b/src/utils/related_links_json_exporter.py
@@ -1,9 +1,11 @@
 import json
 
+
 class RelatedLinksJsonExporter:
     """
     Uses a node2vec model to create a nested list of source_content_ids and their predicted target_content_ids (up to 5)
     """
+
     def __init__(self, related_links):
         self.related_links = related_links
 
@@ -14,8 +16,7 @@ class RelatedLinksJsonExporter:
         :param file_path:
         :return:
         """
-        related_links_json = {k:[vs for vs,_ in v] for k,v in self.related_links.items()}
+        related_links_json = {k: [vs for vs, _ in v] for k, v in self.related_links.items()}
 
         with open(file_path, 'w') as f:
             json.dump(related_links_json, f, ensure_ascii=False)
-

--- a/tests/unit/fixtures/related_links_populated.tsv
+++ b/tests/unit/fixtures/related_links_populated.tsv
@@ -1,0 +1,5 @@
+source_base_path	target_base_path	probability	source_content_id	target_content_id	source_page_views	target_page_views
+/	/about-government	0.51	03680a95-4cd4-46e6-b6d9-ec7aa5fb988e	036e63af-49ee-42e0-b2dd-65cd5acf4152	418	83
+/	/how-government-works	0.49	03680a95-4cd4-46e6-b6d9-ec7aa5fb988e	036ebf91-3da7-442d-ac03-b8efbce90a8d	418	19
+/	/the-government-departments	0.48	03680a95-4cd4-46e6-b6d9-ec7aa5fb988e	0374ee58-fd10-4e16-840e-cdaf6bbd2955	418	126
+/people-in-government	/the-role-of-government	0.83	b43584db-0b4b-4d49-9a65-4d4ec42c9394	eb771368-c26d-4519-a964-0769762b3700	420	34

--- a/tests/unit/utils/test_related_links_csv_exporter.py
+++ b/tests/unit/utils/test_related_links_csv_exporter.py
@@ -41,6 +41,27 @@ def test_related_links_exporter_exports_csv_with_base_paths_when_relatd_links_ex
     assert expected_related_links_csv == exported_csv
 
 
+def test_related_links_exporter_exports_tsv_with_base_paths_when_relatd_links_exist():
+    related_links_with_probabilities = {"03680a95-4cd4-46e6-b6d9-ec7aa5fb988e": [
+        ("036e63af-49ee-42e0-b2dd-65cd5acf4152", 0.51),
+        ("036ebf91-3da7-442d-ac03-b8efbce90a8d", 0.49),
+        ("0374ee58-fd10-4e16-840e-cdaf6bbd2955", 0.48)],
+        "b43584db-0b4b-4d49-9a65-4d4ec42c9394": [
+            ("eb771368-c26d-4519-a964-0769762b3700", 0.83)
+        ]}
+
+    expected_related_links_csv = read_file_as_string("tests/unit/fixtures/related_links_populated.tsv")
+
+    csv_exporter = RelatedLinksCsvExporter(related_links_with_probabilities, _content_id_to_base_path_mapper(),
+                                            _content_id_to_page_view_mapper())
+
+    csv_exporter.export('tests/unit/tmp/related_links_export_test_populated.tsv')
+
+    exported_csv = read_file_as_string("tests/unit/tmp/related_links_export_test_populated.tsv")
+
+    assert expected_related_links_csv == exported_csv
+
+
 def _content_id_to_base_path_mapper():
     return json.loads(json.dumps({
         "03680a95-4cd4-46e6-b6d9-ec7aa5fb988e": "/",


### PR DESCRIPTION
This PR adds support for TSV export, changing the field separator automatically if the required output file has the extension `.tsv`.