### PR TITLE
Use cron resource to trigger link generation

### DIFF
--- a/concourse.yml
+++ b/concourse.yml
@@ -11,10 +11,11 @@ groups:
       - run-ingestion-production
 
 resources:
- - name: every-three-weeks
-   type: time
+ - name: every-two-weeks
+   type: cron-resource
    source:
-     interval: 504h
+    expression: "0 8 9,23 * * *"
+    location: "Europe/London"
 
 jobs:
   - name: run-generation-integration


### PR DESCRIPTION
This PR updates the resource which triggers the link generation to use a `cron-resource` rather than `time`. The purpose of this is to ensure that the pipeline isn't triggered at random times when the underlying Concourse instance is restarted or upgraded, as the `time` resource loses its state when this happens and triggers the pipeline when it next checks if it should be run. The frequency is also changed from every three weeks to every two weeks.