### PR TITLE
Add missing resource type for cron-resource

### DIFF
--- a/concourse.yml
+++ b/concourse.yml
@@ -10,12 +10,19 @@ groups:
       - run-ingestion-staging
       - run-ingestion-production
 
+resource_types:
+  - name: cron-resource
+    type: docker-image
+    source:
+      repository: cftoolsmiths/cron-resource
+      tag: latest
+
 resources:
- - name: every-two-weeks
-   type: cron-resource
-   source:
-    expression: "0 8 9,23 * * *"
-    location: "Europe/London"
+  - name: every-two-weeks
+    type: cron-resource
+    source:
+      expression: "0 8 9,23 * * *"
+      location: "Europe/London"
 
 jobs:
   - name: run-generation-integration


### PR DESCRIPTION
Recently the `cron-resource` was added to the pipeline to control when the generation of related links is kicked off (replacing the `time` resource). As the `cron-resource` is not bundled with Concourse by default, we need to add a custom `resource-type` for it to work, which is what this PR retrospectively does.