### PR TITLE
Add Concourse PR pipeline

### DIFF
--- a/concourse.yml
+++ b/concourse.yml
@@ -9,6 +9,9 @@ groups:
       - run-ingestion-integration
       - run-ingestion-staging
       - run-ingestion-production
+  - name: ci
+    jobs:
+      - pr
 
 resource_types:
   - name: cron-resource
@@ -16,6 +19,10 @@ resource_types:
     source:
       repository: cftoolsmiths/cron-resource
       tag: latest
+  - name: pull-request
+    type: docker-image
+    source:
+      repository: teliaoss/github-pr-resource
 
 resources:
   - name: every-two-weeks
@@ -23,8 +30,75 @@ resources:
     source:
       expression: "0 8 9,23 * * *"
       location: "Europe/London"
+  - name: related-links-pr
+    type: pull-request
+    source:
+      access_token: ((concourse_ci_access_token))
+      repository: alphagov/govuk-related-links-recommender
+      disable_forks: true
+    check_every: 1m
 
 jobs:
+  - name: pr
+    plan:
+      - get: related-links-pr
+        trigger: true
+        version: every
+      - put: related-links-pr
+        params:
+          path: related-links-pr
+          status: pending
+      - task: run-python-tests
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: python
+              tag: 3.6
+          inputs:
+            - name: related-links-pr
+          run:
+            path: bash
+            args:
+              - -c
+              - |
+                set -e pipefail
+
+                pip install -r requirements.txt
+                pytest tests/unit
+            dir: related-links-pr
+      - task: run-ruby-tests
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: ruby
+              tag: 2.6
+          inputs:
+            - name: related-links-pr
+          run:
+            path: bash
+            args:
+              - -c
+              - |
+                set -e pipefail
+
+                gem install bundler
+                bundle
+                rspec spec
+            dir: related-links-pr
+      - put: related-links-pr
+        params:
+          path: related-links-pr
+          status: success
+    on_failure:
+      put: related-links-pr
+      params:
+        path: related-links-pr
+        status: failure
+
   - name: run-generation-integration
     serial_groups: 
       - link-generation

--- a/src/data_preprocessing/make_functional_edges_and_weights.py
+++ b/src/data_preprocessing/make_functional_edges_and_weights.py
@@ -15,20 +15,20 @@ logging.config.fileConfig('src/logging.conf')
 
 
 class EdgeWeightExtractor:
-    logger = logging.getLogger('make_functional_edges_and_weights.EdgeWeightExtractor')
-    credentials, project_id = google.auth.default()
-    logger.info(f'creating bigqquery client for project {project_id}')
-    client = bigquery.Client(
-        credentials=credentials,
-        project=project_id
-    )
-    logger.info('reading query from  src/data_preprocessing/query_content_id_edge_weights.sql')
-    query_edge_list = read_file_as_string("src/data_preprocessing/query_content_id_edge_weights.sql")
-
     def __init__(self, blacklisted_document_types, date_from, date_until):
         self.blacklisted_document_types = blacklisted_document_types
         self.date_from = date_from
         self.date_until = date_until
+
+        logger = logging.getLogger('make_functional_edges_and_weights.EdgeWeightExtractor')
+        credentials, project_id = google.auth.default()
+        logger.info(f'creating bigqquery client for project {project_id}')
+        self.client = bigquery.Client(
+            credentials=credentials,
+            project=project_id
+        )
+        logger.info('reading query from  src/data_preprocessing/query_content_id_edge_weights.sql')
+        self.query_edge_list = read_file_as_string("src/data_preprocessing/query_content_id_edge_weights.sql")
 
         self.query_config = bigquery.QueryJobConfig(
             query_parameters=[


### PR DESCRIPTION
This PR adds CI to run tests when PRs are raised, using Concourse and the GitHub PR Resource (https://github.com/telia-oss/github-pr-resource).

It also refactors `EdgeWeightExtractor` to only initialise the BigQuery client when creating a new instance of this class.