### PR TITLE
Run Python linting as part of CI

### DIFF
--- a/concourse.yml
+++ b/concourse.yml
@@ -53,7 +53,7 @@ jobs:
         params:
           path: related-links-pr
           status: pending
-      - task: run-python-tests
+      - task: run-python-tests-and-linting
         config:
           platform: linux
           image_resource:
@@ -71,6 +71,7 @@ jobs:
                 set -e pipefail
 
                 pip install -r requirements.txt
+                flake8 src
                 pytest tests/unit
             dir: related-links-pr
       - task: run-ruby-tests


### PR DESCRIPTION
This PR adds Python linting as part of CI, using `flake8`.