### PR TITLE
Ensure install/update prompts do not cause pipeline failure

### DIFF
--- a/provision_generation_machine
+++ b/provision_generation_machine
@@ -11,12 +11,12 @@ sudo apt-get install -y jq
 sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 9DA31620334BD75D9DCB49F368818C72E52529D4
 
 echo "deb [ arch=amd64 ] https://repo.mongodb.org/apt/ubuntu bionic/mongodb-org/4.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-4.0.list
-sudo apt-get update
+sudo apt-get update -y
 sudo apt-get install -y mongodb-org
 sudo service mongod start
 
 # Install Python 3 and Pip
-sudo apt-get install python3.6
+sudo apt-get install -y python3.6
 sudo apt install -y python3-pip
 
 # Allow others access to instance


### PR DESCRIPTION
This PR ensures that install/update prompts do not cause pipeline failure by returning a non-zero status code. This appears to be the reason why the pipeline has previously been flaky in when it fails.