### PR TITLE
Auto-update Concourse pipeline

### DIFF
--- a/concourse.yml
+++ b/concourse.yml
@@ -1,6 +1,6 @@
 groups:
   - name: link-generation
-    jobs: 
+    jobs:
       - run-generation-integration
       - run-generation-staging
       - run-generation-production
@@ -12,6 +12,9 @@ groups:
   - name: ci
     jobs:
       - pr
+  - name: meta
+    jobs:
+      - update-pipeline
 
 resource_types:
   - name: cron-resource
@@ -42,8 +45,18 @@ resources:
       repository: alphagov/govuk-related-links-recommender
       disable_forks: true
     check_every: 1m
+  - name: related-links-recommender-repo
+    type: git
+    source:
+      uri: https://github.com/alphagov/govuk-related-links-recommender.git
 
 jobs:
+  - name: update-pipeline
+    plan:
+      - get: related-links-recommender-repo
+        trigger: true
+      - set_pipeline: govuk-related-links
+        file: related-links-recommender-repo/concourse.yml
   - name: pr
     plan:
       - get: related-links-pr
@@ -106,7 +119,7 @@ jobs:
         status: failure
 
   - name: run-generation-integration
-    serial_groups: 
+    serial_groups:
       - link-generation
     plan:
       - task: create-generation-instance
@@ -158,13 +171,13 @@ jobs:
                 sleep 30
 
                 instance_id=$(aws ec2 describe-instances --region eu-west-1 --query "Reservations[*].Instances[*].InstanceId" --filters Name=instance-state-name,Values=running,pending  Name=tag:Name,Values=related-links-generation --output=text)
-                
+
                 echo "Waiting on instance ${instance_id}..."
 
                 aws ec2 wait instance-status-ok \
                   --region eu-west-1 \
                   --instance-ids ${instance_id}
-                
+
                 echo "Instance available and ready"
       - task: provision-instance
         config:
@@ -194,7 +207,7 @@ jobs:
                 chmod 400 /tmp/concourse_ssh_key
 
                 instance_ip=$(aws ec2 describe-instances --region eu-west-1 --query "Reservations[*].Instances[*].PublicIpAddress" --filter Name=tag:Name,Values=related-links-generation --output=text)
-                
+
                 echo "Connecting to instance..."
                 ssh -i /tmp/concourse_ssh_key -o StrictHostKeyChecking=no ubuntu@${instance_ip} << EOF
                   echo "Connected!"
@@ -258,7 +271,7 @@ jobs:
                 echo "ServerAliveInterval 300" >> /etc/ssh/ssh_config
 
                 instance_id=$(aws ec2 describe-instances --region eu-west-1 --query "Reservations[*].Instances[*].PublicIpAddress" --filter Name=tag:Name,Values=related-links-generation --output=text)
-                
+
                 echo "Connecting to instance..."
                 ssh -i /tmp/concourse_ssh_key -o StrictHostKeyChecking=no ubuntu@${instance_id} <<EOF
                   echo "Connected!"
@@ -286,9 +299,9 @@ jobs:
     on_failure: *destroy-generation-instance-integration
 
   - name: run-generation-staging
-    serial_groups: 
+    serial_groups:
       - link-generation
-    
+
     plan:
       - task: create-generation-instance
         config:
@@ -358,9 +371,9 @@ jobs:
     on_failure: *destroy-generation-instance-staging
 
   - name: run-generation-production
-    serial_groups: 
+    serial_groups:
       - link-generation
-    
+
     plan:
       - get: every-two-weeks-generation
         trigger: true
@@ -432,7 +445,7 @@ jobs:
     on_failure: *destroy-generation-instance-production
 
   - name: run-ingestion-integration
-    serial_groups: 
+    serial_groups:
       - link-ingestion
     plan:
       - task: create-ingestion-instance
@@ -472,13 +485,13 @@ jobs:
                 sleep 30
 
                 instance_id=$(aws ec2 describe-instances --region eu-west-1 --query "Reservations[*].Instances[*].InstanceId" --filters Name=instance-state-name,Values=running,pending  Name=tag:Name,Values=related-links-ingestion --output=text)
-                
+
                 echo "Waiting on instance ${instance_id}..."
 
                 aws ec2 wait instance-status-ok \
                   --region eu-west-1 \
                   --instance-ids ${instance_id}
-                
+
                 echo "Instance available and ready"
       - task: provision-ingestion-instance
         config:
@@ -508,7 +521,7 @@ jobs:
                 chmod 400 /tmp/concourse_ssh_key
 
                 instance_ip=$(aws ec2 describe-instances --region eu-west-1 --query "Reservations[*].Instances[*].PublicIpAddress" --filter Name=tag:Name,Values=related-links-ingestion --output=text)
-                
+
                 echo "Connecting to instance ${instance_ip}..."
                 ssh -i /tmp/concourse_ssh_key -o StrictHostKeyChecking=no ubuntu@${instance_ip} << EOF
                   echo "Connected!"
@@ -572,7 +585,7 @@ jobs:
                 echo "ServerAliveInterval 300" >> /etc/ssh/ssh_config
 
                 instance_ip=$(aws ec2 describe-instances --region eu-west-1 --query "Reservations[*].Instances[*].PublicIpAddress" --filter Name=tag:Name,Values=related-links-ingestion --output=text)
-                
+
                 echo "Connecting to instance..."
                 ssh -i /tmp/concourse_ssh_key -o StrictHostKeyChecking=no ubuntu@${instance_ip} <<EOF
                   echo "Connected!"
@@ -600,7 +613,7 @@ jobs:
     on_failure: *destroy-ingestion-instance-integration
 
   - name: run-ingestion-staging
-    serial_groups: 
+    serial_groups:
       - link-ingestion
     plan:
       - task: create-ingestion-instance
@@ -671,7 +684,7 @@ jobs:
     on_failure: *destroy-ingestion-instance-staging
 
   - name: run-ingestion-production
-    serial_groups: 
+    serial_groups:
       - link-ingestion
     plan:
       - get: every-two-weeks-ingestion


### PR DESCRIPTION
This adds a new job that will watch GitHub for changes to the recommended-links repo and automatically set any pipeline changes that have been made, so one doesn't need to manually make those changes.