### PR TITLE
Change functional network window

### DIFF
--- a/src/data_preprocessing/make_functional_edges_and_weights.py
+++ b/src/data_preprocessing/make_functional_edges_and_weights.py
@@ -50,11 +50,11 @@ if __name__ == "__main__":
     data_dir = os.getenv("DATA_DIR")
     blacklisted_document_types = read_exclusions_yaml(
         "document_types_excluded_from_the_topic_taxonomy.yml")['document_types']
-    yesterday = (datetime.today() - timedelta(1)).strftime('%Y%m%d')
-    three_weeks_ago = (datetime.today() - timedelta(22)).strftime('%Y%m%d')
+    two_days_ago = (datetime.today() - timedelta(2)).strftime('%Y%m%d')
+    start_date = (datetime.today() - timedelta(24)).strftime('%Y%m%d')
 
-    module_logger.info(f'running query between {yesterday} and {three_weeks_ago}')
-    edge_weights = EdgeWeightExtractor(blacklisted_document_types, three_weeks_ago, yesterday)
+    module_logger.info(f'running query between {two_days_ago} and {start_date}')
+    edge_weights = EdgeWeightExtractor(blacklisted_document_types, start_date, two_days_ago)
 
     module_logger.info(f'saving edges and weights to {os.path.join(data_dir, "tmp", "functional_edges.csv")}')
     edge_weights.extract_df_to_csv(os.path.join(data_dir, "tmp", "functional_edges.csv"))


### PR DESCRIPTION
This PR changes the functional network window (i.e. the period for which we obtain user movement data) so that we use data up to two days ago (changed from the previous day). The reason for this change is that Google moves data from a Google Analytics view into a specific BigQuery table on a daily basis, and this happens in the early hours of the day pacific standard time. As a result, we have no guarantee that the data we need in BigQuery is present when running the related links pipeline at 8am.

The change in this commit addresses this problem by generating data for two days ago from the current date, which is guaranteed to be in BigQuery.