### PR TITLE
Use logging within node2vec

### DIFF
--- a/src/utils/epoch_logger.py
+++ b/src/utils/epoch_logger.py
@@ -1,16 +1,24 @@
 from gensim.models.callbacks import CallbackAny2Vec
+from logging import getLogger
 
 
 class EpochLogger(CallbackAny2Vec):
-    """Callback to log information about training'"""
+    """Callback to log information about training"""
 
     def __init__(self):
         self.epoch = 0
-        print('EpochLogger initiated, epoch = 0')
+        self.logger = getLogger('gensim_node2vec')
+        self.logger.info('EpochLogger initiated, epoch = 0')
 
     def on_epoch_begin(self, model):
-        print(f'Model training epoch #{self.epoch} began')
+        self.logger.info(f'Model training epoch #{self.epoch} begins')
 
     def on_epoch_end(self, model):
-        print(f'Model training epoch #{self.epoch} ended')
+        self.logger.info(f'Model training epoch #{self.epoch} ends')
         self.epoch += 1
+
+    def on_train_begin(self, model):
+        self.logger.info(f'Model training begins')
+
+    def on_train_end(self, model):
+        self.logger.info(f'Model raining ends')


### PR DESCRIPTION
So far all logging within node2vec used printf, which probably explains why the messages were buffered and were only dumped once the training was over. This would explain the 5-hour gap in the log which might be the cause of the disconnects.

Also, using logging will give us timestamps to verify this.
