### PR TITLE
Tail syslog to find out if machine is terminated

### DIFF
--- a/monitor_related_links_process
+++ b/monitor_related_links_process
@@ -5,7 +5,7 @@ set -eo pipefail
 LINK_PROCESS_PID="$(ps aux | grep run_link_ | grep -v grep | awk '{print $2}')"
 echo "PID of the link generation / ingestion process is $LINK_PROCESS_PID"
 
-tail -f --pid=$LINK_PROCESS_PID /var/tmp/related_links_process.log
+tail -f --pid=$LINK_PROCESS_PID /var/tmp/related_links_process.log /var/log/syslog
 
 LOG_LAST_LINE=$(tail -n 1 /var/tmp/related_links_process.log)
 if [ "$LOG_LAST_LINE" != "related_links process succeeded" ]; then


### PR DESCRIPTION
We need to find out why the machine gets terminated before the process ends.
Seeing the system log might help us find out what happens