### PR TITLE
Increase python version for CI tests

### DIFF
--- a/concourse.yml
+++ b/concourse.yml
@@ -75,7 +75,7 @@ jobs:
             type: docker-image
             source:
               repository: python
-              tag: 3.6
+              tag: 3.7
               username: ((docker_hub_username))
               password: ((docker_hub_authtoken))
           inputs:


### PR DESCRIPTION
We need to upgrade the concourse file first before we update the python version elsewhere and the dependencies.