### PR TITLE
Remove integration special rule

### DIFF
--- a/concourse.yml
+++ b/concourse.yml
@@ -197,7 +197,6 @@ jobs:
             ROLE_ARN: ((concourse_role_arn_integration))
             CONTENT_STORE_BUCKET: ((content_store_bucket_integration))
             RELATED_LINKS_BUCKET: ((related_links_bucket_integration))
-            GIT_BRANCH_TO_CLONE: integration
           platform: linux
           image_resource:
             type: docker-image
@@ -234,7 +233,7 @@ jobs:
                   cd /var/data/github
 
                   # Clone related links repository
-                  git clone --branch "$GIT_BRANCH_TO_CLONE" https://github.com/alphagov/govuk-related-links-recommender.git
+                  git clone https://github.com/alphagov/govuk-related-links-recommender.git
                   cd govuk-related-links-recommender
 
                   # Set execute permission on scripts
@@ -339,7 +338,6 @@ jobs:
             ROLE_ARN: ((concourse_role_arn_staging))
             CONTENT_STORE_BUCKET: ((content_store_bucket_staging))
             RELATED_LINKS_BUCKET: ((related_links_bucket_staging))
-            GIT_BRANCH_TO_CLONE: master
           platform: linux
           image_resource:
             type: docker-image
@@ -424,7 +422,6 @@ jobs:
             ROLE_ARN: ((concourse_role_arn_production))
             CONTENT_STORE_BUCKET: ((content_store_bucket_production))
             RELATED_LINKS_BUCKET: ((related_links_bucket_production))
-            GIT_BRANCH_TO_CLONE: master
           platform: linux
           image_resource:
             type: docker-image
@@ -527,7 +524,6 @@ jobs:
             PUBLISHING_API_URI: ((publishing_api_uri_integration))
             PUBLISHING_API_BEARER_TOKEN: ((publishing_api_bearer_token_integration))
             RELATED_LINKS_BUCKET: ((related_links_bucket_integration))
-            GIT_BRANCH_TO_CLONE: integration
           platform: linux
           image_resource:
             type: docker-image
@@ -564,7 +560,7 @@ jobs:
                   cd /var/data/github
 
                   # Clone related links repository
-                  git clone --branch "$GIT_BRANCH_TO_CLONE" https://github.com/alphagov/govuk-related-links-recommender.git
+                  git clone https://github.com/alphagov/govuk-related-links-recommender.git
                   cd govuk-related-links-recommender
 
                   # Set execute permission on scripts
@@ -668,7 +664,6 @@ jobs:
             PUBLISHING_API_URI: ((publishing_api_uri_staging))
             PUBLISHING_API_BEARER_TOKEN: ((publishing_api_bearer_token_staging))
             RELATED_LINKS_BUCKET: ((related_links_bucket_staging))
-            GIT_BRANCH_TO_CLONE: master
           platform: linux
           image_resource:
             type: docker-image
@@ -752,7 +747,6 @@ jobs:
             PUBLISHING_API_URI: ((publishing_api_uri_production))
             PUBLISHING_API_BEARER_TOKEN: ((publishing_api_bearer_token_production))
             RELATED_LINKS_BUCKET: ((related_links_bucket_production))
-            GIT_BRANCH_TO_CLONE: master
           platform: linux
           image_resource:
             type: docker-image


### PR DESCRIPTION
Integration is used as a special branch to release to the integration envuironment
This PR removes this as it doesn't really help and introduces confusion