### PR TITLE
Force python3.7 when using pip3

### DIFF
--- a/provision_generation_machine
+++ b/provision_generation_machine
@@ -19,6 +19,11 @@ sudo service mongod start
 sudo apt-get install -y python3.7
 sudo apt install -y python3-pip
 
+# Make sure python 3.7 is used by python3, python, pip3 and pip
+sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 1
+sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.7 1
+sudo update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
+
 # Allow others access to instance
 echo "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDDAZQOvxUVgi4IWwfEqYQkqU2b9RGpEHfCB48CmwdRP3WY8Cfre/GH6gw+wLvNvIDuUGLr2hwBhvqoWxsC0EeDMTvgYQE6//zb3ZCw6owMdSmkzHfSkcVvM4JGvuNWIOFYIcMtF9DkGddM5jQD9Inzb+TtPaQjrp8u4hZqr0agjSxwQGxa6hl0TfI4zXNg5Q4TXdEDuhauGomUN+6hK4wRfJW2cdXZBadAbDHAsMNrbEPBcaD8z+SJ23qT5mE5N4aGxbscKqNfq0hTdHUUzDY3Y5bw/Odt5Z9JZNE3/amBwMDRBF0oIEs1+jztRgjPZq2o2jl9EFpu7XToZU+1LGs8m4JDAAyf4BgwX5kdIrkO/MOEsGTY/dqnpwzNNBzfE4pxW4P4frqS1xPP4X5DbDiVD2lu4adffaMOmPU8cy9YyMMxEK62yCCMry1TU7SYr/o1gRcIPRk2m3ZifODZEp9AStRwAeWQfn2fgv2naL8wVd24pdl2/LKuxe1txQTwc6KFKOAylUCEHUJ2NDG5x2XSAGmE/oecUgexxIgHR2nhG3YRt30T8qimEPrY7Tarb3Dei/kHTBJkg3wOLRMGG81L0cE9wvTt6em5jtKXU/tvB16lvi5cgNO++Lmy7GlcZYfbdYZi/CELCBEZye5m9vZT7Jzm26JK75HA3sgtqajMKw== suganya.sivaskantharajah@digital.cabinet-office.gov.uk" >> /home/ubuntu/.ssh/authorized_keys
 echo "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCo6AI0U+VFs2dkrwNDMKcU7j5lhSPFDuboQrsGyC1tv8aUBlCSfVDaPRPT20lYANN7tFgQD9mKXaMlUd9bCJJFs7L3CbE+/kSQCE85rfPFDaTMb3/WzYzwMjDD05pRtvdBwmkS6o8IFA4Yyd29qahYhnrO3jexBIZnNdM4nWZCac+nX/8bWckPOGWIR7fTNWoS8C8tioiUDqa/ZflzGqA0NKv7M0I1kwKqHt25FHaqZxnGmnKEC9QIUGbS4cC1cJQ2AO3NqJGPWhb39QrZwvv+Juh9rU3vuohDfx7Xm1Lh8NMVf3+c1vNTcK+DvaGGLZJ20JUBXlRRFFviLo9eaaf5fHIn5bM9aKFwxoPZtlj73FQpv04bUJf/LlbnGgLeW+B6Pl2w2qFp3u5p5NtvPEnLLPm4ljiPsJwl6vdmZy/xLc8/Ze0xyOeMaENm9MFK8BykgBqXqmEsSntvryP2fp1LgwDOt9ufLpF+yLq6hXl/JKYDJZiCTUjpwSbO/GRbsf2PCjzcwLxKIru3QtR9IZmiopeYRbDvH6Zofs/4M4mQVlBv15CKthVSTwwvcb9vOQyRa2uRW6FkY//g04+2yXpU742Cuh0CgNUd1fJ/vO3kCO0Fup/m3M0B7Vsr4NE5/0XdZSXOd5sF9oB4uVh9vE7apD0+hGbeQHzXz5cRNn52KQ== karl.alec.baker@gmail.com" >> /home/ubuntu/.ssh/authorized_keys


### PR DESCRIPTION
pip3 was still reporting python 3.6, so we're now forcing 3.7 everywhere.
