### PR TITLE
Revert "change workers in config yaml from None to null so it gets read properly"

### DIFF
--- a/src/config/node2vec-config.yml
+++ b/src/config/node2vec-config.yml
@@ -11,7 +11,7 @@ seed: 1
 #Epochs
 iter: 5
 # n cpus to use (null = cpu.count())
-workers: null
+workers: None
 # no file type suffix
 embeddings_filename: "n2v_node_embeddings"
 #run_link_generation will only upload models called n2v.model


### PR DESCRIPTION
Reverts alphagov/govuk-related-links-recommender#129

Reverting all our changes before related links reruns in prod. Changes have been preserved in the [weighted-related-links](https://github.com/alphagov/govuk-related-links-recommender/commits/weighted-related-links) 