### PR TITLE
Set GOVUK_APP_NAME env variable for ingestion job

### DIFF
--- a/concourse.yml
+++ b/concourse.yml
@@ -586,6 +586,7 @@ jobs:
                   chmod +x ./run_link_ingestion
 
                   # Make environment variables accessible to scripts
+                  export GOVUK_APP_NAME="govuk-related-links-recommender"
                   export RELATED_LINKS_BUCKET="$RELATED_LINKS_BUCKET"
                   export PUBLISHING_API_URI="$PUBLISHING_API_URI"
                   export PUBLISHING_API_BEARER_TOKEN="$PUBLISHING_API_BEARER_TOKEN"


### PR DESCRIPTION
This will allow gds-api-adapters to [include the application name in the user agent field](https://github.com/alphagov/gds-api-adapters/blob/4ca2658628b5b9bd8d003d4c51e86343acd0398a/lib/gds_api/json_client.rb#L27), which will make it easier to identify which application is making requests when viewing logs.