### PR TITLE
Go back to unweighted version

### DIFF
--- a/src/config/node2vec-config.yml
+++ b/src/config/node2vec-config.yml
@@ -1,5 +1,5 @@
 # Use edge weights in graph
-weighted_graph: True
+weighted_graph: False
 # Node2vec hyper params
 dimensions: 64
 walk_length: 10


### PR DESCRIPTION
We've now checked that the weighted version works well even in production, so going back to the old one until we've established if the weighted links work better.