### PR TITLE
switch back to weighted related links

### DIFF
--- a/src/config/node2vec-config.yml
+++ b/src/config/node2vec-config.yml
@@ -1,5 +1,5 @@
 # Use edge weights in graph
-weighted_graph: False
+weighted_graph: True
 # Node2vec hyper params
 dimensions: 64
 walk_length: 10


### PR DESCRIPTION
to start the "B2" phase of the weighted related links test, we need to switch back to wighted to generate the 2nd set of weighted related links