### PR TITLE
Temporarily suspend generation

### DIFF
--- a/concourse.yml
+++ b/concourse.yml
@@ -403,7 +403,7 @@ jobs:
 
     plan:
       - get: every-two-weeks-generation
-        trigger: true
+        trigger: false
       - task: create-generation-instance
         config:
           params:
@@ -746,7 +746,7 @@ jobs:
       - link-ingestion
     plan:
       - get: every-two-weeks-ingestion
-        trigger: true
+        trigger: false
       - task: create-ingestion-instance
         config:
           params:


### PR DESCRIPTION
We're running the weighted related links AABB testing until
22/12/2021. So we need to skip the normal run on 9/12.
