### PR TITLE
Ignore renamed document type

### DIFF
--- a/src/config/document_types_excluded_from_the_topic_taxonomy.yml
+++ b/src/config/document_types_excluded_from_the_topic_taxonomy.yml
@@ -58,4 +58,5 @@ document_types:
   - uk_market_conformity_assessment_body
   - working_group
   - world_location
+  - world_location_news
   - worldwide_organisation

--- a/tests/unit/utils/test_miscellaneous.py
+++ b/tests/unit/utils/test_miscellaneous.py
@@ -62,6 +62,7 @@ def test_get_excluded_document_types():
                  'uk_market_conformity_assessment_body',
                  'working_group',
                  'world_location',
+                 'world_location_news',
                  'worldwide_organisation']
 
     assert doc_types == read_config_yaml("document_types_excluded_from_the_topic_taxonomy.yml")[


### PR DESCRIPTION
GOV.UK have renamed the placeholder_world_location_news_page document type
to world_location_news. Since this is a document type we ignore we need to
add the new name in the exclude file. We can keep the old one while they make
the transition.