### PR TITLE
Exclude animal_disease_case from related links

### DIFF
--- a/src/config/document_types_excluded_from_the_topic_taxonomy.yml
+++ b/src/config/document_types_excluded_from_the_topic_taxonomy.yml
@@ -2,6 +2,7 @@ document_types:
   - about
   - about_our_services
   - access_and_opening
+  - animal_disease_case
   - business_support_finder
   - coming_soon
   - complaints_procedure

--- a/tests/unit/utils/test_miscellaneous.py
+++ b/tests/unit/utils/test_miscellaneous.py
@@ -6,6 +6,7 @@ def test_get_excluded_document_types():
     doc_types = ['about',
                  'about_our_services',
                  'access_and_opening',
+                 'animal_disease_case',
                  'business_support_finder',
                  'coming_soon',
                  'complaints_procedure',


### PR DESCRIPTION
This adds animal_disease_case document type to the exclusion list, so individual animal cases don't populate the automatically generated related links section.