### PR TITLE
Add missing Dependabot config file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: daily
+
+  - package-ecosystem: bundler
+    directory: /
+    schedule:
+      interval: daily


### PR DESCRIPTION
Our KR for Q2 is to ensure 100% of GOV.UK repos that have dependencies have a Dependabot config file to facilitate teams keeping their dependencies up to date.

https://trello.com/c/fkn9U2C7/3304-add-missing-dependabot-config-files-3